### PR TITLE
add url base auto switch role feature

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "AWS Extend Switch Roles",
   "description": "Extend your AWS IAM switching roles. You can set the configuration like aws config format",
   "short_name": "Extend SwitchRole",
-  "permissions": ["activeTab", "storage"],
+  "permissions": ["activeTab", "storage", "tabs"],
   "icons" : {
     "48": "icons/Icon_48x48.png",
     "128": "icons/Icon_128x128.png"

--- a/src/lib/create_role_list_item.js
+++ b/src/lib/create_role_list_item.js
@@ -48,7 +48,7 @@ export function createRoleListItem(document, item, url, region, { hidesAccountId
   return li
 }
 
-function createRedirectUri(currentUrl, curRegion, destRegion) {
+export function createRedirectUri(currentUrl, curRegion, destRegion) {
   let redirectUri = currentUrl;
   if (curRegion && destRegion && curRegion !== destRegion) {
     redirectUri = redirectUri.replace('region=' + curRegion, 'region=' + destRegion);


### PR DESCRIPTION
```
[profile hoge]
region=ap-northeast-1
role_arn=arn:aws:iam::account-id:role/role-name
match_url=some-code-build-project|sqs|dynamodb
```

Added the feature to automatically switch role to roles that match <code>match_url</code> patterns